### PR TITLE
(SIMP-254) Update rsync to reflect global_etc changes

### DIFF
--- a/build/pupmod-common.spec
+++ b/build/pupmod-common.spec
@@ -80,7 +80,9 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Mon Jun 15 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-20
+* Thu Jul 09 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-20
+- Do not attempt to rsync crontab or anacrontab by default; we no
+  longer supply them in rsync global_etc.
 - Added a function to parse host strings/urls.  Returns a hash of
   hostnames with an array of ports and an array of protocols.
   Modified strip_ports to use parse_hosts and added get_ports to

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -57,19 +57,6 @@ class common::cron (
   }
 
   if $use_rsync {
-    rsync { 'anacrontab':
-      source  => "${rsync_root}/anacrontab",
-      target  => '/etc/anacrontab',
-      server  => $rsync_server,
-      timeout => $rsync_timeout
-    }
-
-    rsync { 'crontab':
-      source  => "${rsync_root}/crontab",
-      target  => '/etc/crontab',
-      server  => $rsync_server,
-      timeout => $rsync_timeout
-    }
 
     rsync { 'cron':
       source  => "${rsync_root}/cron.*",

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -7,16 +7,12 @@ describe 'common::cron' do
   it { should create_concat_build('cron').with_target('/etc/cron.allow') }
   it { should create_file('/etc/cron.allow').that_subscribes_to('Concat_build[cron]') }
   it { should create_file('/etc/cron.deny').with_ensure('absent') }
-  it { should create_rsync('anacrontab') }
-  it { should create_rsync('crontab') }
   it { should create_rsync('cron') }
 
   context 'no_rsync' do
     let(:params){{ :use_rsync => false }}
 
     it { should compile.with_all_deps }
-    it { should_not create_rsync('anacrontab') }
-    it { should_not create_rsync('crontab') }
     it { should_not create_rsync('cron') }
   end
 


### PR DESCRIPTION
We no longer supply crontab or anacrontab in global_etcd, so
don't rsync them in puppet.

SIMP-254 #close Update rysnc for global_etc.
Change-Id: Ie3bcc318c315757cc513114def25f2a0f3067c14
