### PR TITLE
(SIMP-490) Added FIPS packages when use_fips set

### DIFF
--- a/lib/facter/cpuinfo.rb
+++ b/lib/facter/cpuinfo.rb
@@ -1,0 +1,38 @@
+# Returns the contents of /proc/cpuinfo as a hash
+# The numeric entries in this should be changed to their proper data types in
+# the future
+
+Facter.add('cpuinfo') do
+  confine { Gem::Version.new(Facter.version) >= Gem::Version.new('2') }
+  confine { File.exist?('/proc/cpuinfo') }
+
+  setcode do
+    retval = {}
+    begin
+    File.read('/proc/cpuinfo').split(/^\s*$/).each do |section|
+      procinfo = section.split("\n").map{|x| x = x.split(':').map(&:strip)}
+    
+      entry_hash = {}
+      procinfo.each do |entry|
+        next if (!entry || entry.empty?)
+    
+        key = entry.first.gsub(/\s+/,'_')
+        value = entry.last
+    
+        if key == 'flags'
+          value = value.split(/\s+/)
+        end
+    
+        entry_hash[key] = value
+      end
+    
+      proc_id = entry_hash.delete('processor')
+    
+      retval[%(processor#{proc_id})] = entry_hash
+    end
+    rescue => details
+      Facter.warn("Could not gather data from /proc/cpuinfo: #{details.message}")
+    end
+    retval
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -32,6 +32,8 @@ describe 'common' do
     it {
       should create_kernel_parameter('fips').with_value('1')
       should create_kernel_parameter('fips').with_bootmode('normal')
+      should create_package('dracut-fips').with_ensure('latest')
+      should create_package('fipscheck').with_ensure('latest')
     }
     it { should create_kernel_parameter('boot').with_value("UUID=#{facts[:boot_dir_uuid]}") }
     it { should create_reboot_notify('fips') }


### PR DESCRIPTION
Added a fact to return all CPU info as a hash and added all relevant
FIPS packages when applicable as well as running dracut -f when the
dracut-fips package is updated.

SIMP-490 #close #comment FIPS Package Updates
