### PR TITLE
(SIMP-627) Update package_metadata

### DIFF
--- a/build/package_metadata.yaml
+++ b/build/package_metadata.yaml
@@ -2,5 +2,5 @@
 # This RPM is required by the main SIMP RPM
 optional: false
 valid_versions :
- - '4\.(2|1).*'
- - '5\.(1|0).*'
+ - '4\.1.*'
+ - '5\.0.*'


### PR DESCRIPTION
SIMP-627 #comment Removed `common` from 4.2/5.1 in package_metadata
